### PR TITLE
V1.2优化

### DIFF
--- a/js/JMX.js
+++ b/js/JMX.js
@@ -656,7 +656,10 @@ class JMXGenerator {
             let request = new JMXRequest(item, this.domains);
             let httpSamplerProxy = new HTTPSamplerProxy(name || "", request);
             httpSamplerProxy.put(new HeaderManager(name + " Headers", item.headers));
-
+            //导出jmx时过滤跨域options的接口
+            if (item.method.toUpperCase() === 'OPTIONS') {
+                return ;
+            }
             if (item.method.toUpperCase() === 'GET') {
                 httpSamplerProxy.add(new HTTPSamplerArguments(request.parameters));
             } else {

--- a/js/JMX.js
+++ b/js/JMX.js
@@ -232,7 +232,7 @@ class TransactionController extends DefaultTestElement {
 
 class HTTPSamplerProxy extends DefaultTestElement {
     constructor(testName, request) {
-        super('HTTPSamplerProxy', 'HttpTestSampleGui', 'HTTPSamplerProxy', testName);
+        super('HTTPSamplerProxy', 'HttpTestSampleGui', 'HTTPSamplerProxy', '【'+ request.method +'】'+ testName);
         this.request = request || {};
 
         this.stringProp("HTTPSampler.domain", this.request.hostname);


### PR DESCRIPTION
1. 导出jmx时过滤options
2. httpsampler名字格式调整为【request.method】+ testName